### PR TITLE
Fix memory leak in contour caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ sudo apt install python3 python3-pip python3-venv git
 python3 -m venv my_venv
 # Switch to venv
 . ./my_venv/bin/activate
-# Install pyhgtmap with dependencies from PyPi
+# Install latest pyhgtmap development version from github
 pip install -U git+https://github.com/agrenott/pyhgtmap.git
 ```
 

--- a/pyhgtmap/hgt/processor.py
+++ b/pyhgtmap/hgt/processor.py
@@ -255,8 +255,42 @@ class HgtFilesProcessor:
                 ),
             )
 
+        # import objgraph
+        # import tracemalloc
+        # import random
+
+        # tracemalloc.start(10)
         for file_name, check_poly in files:
             self.process_file(file_name, check_poly)
+            # snapshot = tracemalloc.take_snapshot()
+            # top_stats = snapshot.statistics("traceback")
+            # # logger.debug("[memory top 10]\n  "+"\n  ".join([str(s) for s in top_stats[:10]]))
+            # logger.debug("===== Memory usage =====")
+            # for stat in top_stats[:10]:
+            #     logger.debug(
+            #         "%s memory blocks: %.1f KiB" % (stat.count, stat.size / 1024)
+            #     )
+            #     logger.debug("\n ".join(stat.traceback.format()))
+
+            # logger.debug("nb files: %s; nb tiles: %s", objgraph.count("hgtFile"), objgraph.count("hgtTile"))
+            # tiles = objgraph.by_type("hgtTile")
+            # objgraph.show_backrefs(tiles, filename="tiles_refs.png")
+            # objgraph.show_most_common_types()
+            # objgraph.show_growth(limit=3)
+            # try:
+            #     objgraph.show_chain(
+            #         objgraph.find_backref_chain(
+            #             random.choice(objgraph.by_type("WayType")),
+            #             objgraph.is_proper_module,
+            #         ),
+            #         filename="chain.png",
+            #     )
+            # except Exception:
+            #     pass
+            # roots = objgraph.get_leaking_objects()
+            # logger.debug("Leaking objects: %s", objgraph.show_most_common_types(objects=roots))
+            # objgraph.show_refs(roots[:3], refcounts=True, filename='roots.png')
+            # # objgraph.show_refs([y], filename='sample-graph.png')
         logger.debug("Done scheduling, waiting for all children to complete...")
 
         self.join_children()

--- a/pyhgtmap/hgt/tile.py
+++ b/pyhgtmap/hgt/tile.py
@@ -1,5 +1,5 @@
 import logging
-from functools import cache
+from functools import lru_cache
 from typing import Any, Dict, Iterable, List, NamedTuple, Tuple
 
 import numpy
@@ -47,6 +47,9 @@ class hgtTile:
         self.minEle, self.maxEle = self.getElevRange()
         self.elevations = None
         self.contourData = None
+        # Use cache local to this instance to avoid memory leak
+        # https://stackoverflow.com/a/68550238
+        self.get_contours = lru_cache(maxsize=16)(self._get_contours)
 
     def get_stats(self) -> str:
         """Get some statistics about the tile."""
@@ -151,8 +154,7 @@ class hgtTile:
                 lon = self.minLon + lonIndex * self.lonIncrement
                 plotFile.write("{0:.7f} {1:.7f} {2:d}\n".format(lon, lat, height))
 
-    @cache
-    def get_contours(
+    def _get_contours(
         self,
         step_cont=20,
         max_nodes_per_way=0,


### PR DESCRIPTION
The hgtTile.get_contour cache was a common one, thus accumulating data for each generated tile. Fixed it to be hgtTile instance specific.

Memory debugging code left commented for reference, to be cleaned later.

Fixes #16