### PR TITLE
Fix node IDs overflow

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -8,4 +8,4 @@ name = "python"
 
 [[analyzers]]
 name = "test-coverage"
-enabled = true
+enabled = false

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![types - Mypy](https://img.shields.io/badge/types-Mypy-blue.svg)](https://github.com/python/mypy)
 [![DeepSource](https://deepsource.io/gh/agrenott/pyhgtmap.svg/?label=active+issues&show_trend=true&token=2WJPDv60DJYqaFeVT85eTdGE)](https://deepsource.io/gh/agrenott/pyhgtmap/?ref=repository-badge)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/1251b91e12da4329bd09856d526c91b3)](https://app.codacy.com/gh/agrenott/pyhgtmap/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
-[![Maintainability](https://api.codeclimate.com/v1/badges/0af92f6750f1bc0840a3/maintainability)](https://codeclimate.com/github/agrenott/pyhgtmap/maintainability)
+[![Maintainability](https://api.codeclimate.com/v1/badges/96551164b79ce7e76500/maintainability)](https://codeclimate.com/github/agrenott/pyhgtmap/maintainability)
 
 pyhgtmap is a fork of the original ![phyghtmap](http://katze.tfiu.de/projects/phyghtmap/) tool,
 which doesn't seem to be maintained anymore.

--- a/pyhgtmap/hgt/processor.py
+++ b/pyhgtmap/hgt/processor.py
@@ -36,10 +36,10 @@ class HgtFilesProcessor:
             options (optparse options): general options
         """
         self.next_node_id: Synchronized = cast(
-            Synchronized, multiprocessing.Value("i", node_start_id)
+            Synchronized, multiprocessing.Value("L", node_start_id)
         )
         self.next_way_id: Synchronized = cast(
-            Synchronized, multiprocessing.Value("i", way_start_id)
+            Synchronized, multiprocessing.Value("L", way_start_id)
         )
         self.available_children = multiprocessing.Semaphore(nb_jobs)
         self.parallel: bool = nb_jobs > 1

--- a/tests/hgt/test_processor.py
+++ b/tests/hgt/test_processor.py
@@ -309,3 +309,21 @@ class TestHgtFilesProcessor:
                 default_options, ["file1.hgt"], (0, 1, 2, 3)
             )
             assert output1 is output2
+
+    @staticmethod
+    def test_node_id_overflow(default_options: SimpleNamespace) -> None:
+        # Ensure node ID doesn't overflow limit of int32
+        processor = HgtFilesProcessor(
+            1, node_start_id=2147483647, way_start_id=200, options=default_options
+        )
+        assert processor.get_and_inc_counter(processor.next_node_id, 1) == 2147483647
+        assert processor.get_and_inc_counter(processor.next_node_id, 1) == 2147483648
+
+    @staticmethod
+    def test_way_id_overflow(default_options: SimpleNamespace) -> None:
+        # Ensure way ID doesn't overflow limit of int32
+        processor = HgtFilesProcessor(
+            1, node_start_id=100, way_start_id=2147483647, options=default_options
+        )
+        assert processor.get_and_inc_counter(processor.next_way_id, 1) == 2147483647
+        assert processor.get_and_inc_counter(processor.next_way_id, 1) == 2147483648

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -233,6 +233,29 @@ class TestOutputPbf:
             # Check file size to ensure there's no major drop in efficiency (compression, dense encoding)
             assert os.stat(osm_file_name).st_size < 420
 
+    @staticmethod
+    def test_node_id_overflow(
+        tile_contours: TileContours,
+        elev_classifier,
+        bounding_box: Tuple[float, float, float, float],
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            osm_file_name = os.path.join(tempdir, "output.osm.pbf")
+            osm_output = pbfUtil.Output(
+                osm_file_name,
+                osmVersion=0.6,
+                pyhgtmap_version="123",
+                bbox=bounding_box,
+                elevClassifier=elev_classifier,
+            )
+            start = 2147483647
+            next_node_id, ways = osm_output.write_nodes(
+                tile_contours, ' time="some time"', start, 0.6
+            )
+
+            # Check int32 boundary has been passed without issue
+            assert next_node_id == 2147483655
+
 
 class TestOutputO5m:
     @staticmethod


### PR DESCRIPTION
Use unsigned 64 bits counter for nodes and ways IDs instead of signed 32 bits.

Fixes #20