### PR TITLE
Handle GDrive expired token

### DIFF
--- a/tests/sources/conftest.py
+++ b/tests/sources/conftest.py
@@ -1,0 +1,20 @@
+"""Common pytest fixtures"""
+
+from typing import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def gauth_mock() -> Generator[MagicMock, None, None]:
+    """Mock pyhgtmap.sources.sonny.GoogleAuth"""
+    with patch("pyhgtmap.sources.sonny.GoogleAuth") as gauth_mock:
+        yield gauth_mock
+
+
+@pytest.fixture
+def gdrive_mock() -> Generator[MagicMock, None, None]:
+    """Mock pyhgtmap.sources.sonny.GoogleDrive"""
+    with patch("pyhgtmap.sources.sonny.GoogleDrive") as gdrive_mock:
+        yield gdrive_mock


### PR DESCRIPTION
GDrive refresh tokens expire after 7 days on test accounts. In such case, force deletion of saved credential and full auth flow.

Close #40