### PR TITLE
Explicitly fail on non-rectangular tiles in WSG84

### DIFF
--- a/pyhgtmap/__init__.py
+++ b/pyhgtmap/__init__.py
@@ -5,11 +5,6 @@ __author__ = "Aurélien Grenotton (agrenott@gmail.com)"
 __version__ = version("pyhgtmap")
 __license__ = "GPLv2+"
 
-# Can't use __future__ annotations for type aliases: https://github.com/python/cpython/issues/95805
-# Some type aliases
-Polygon = list[tuple[float, float]]
-PolygonsList = list[Polygon]
-
 
 class BBox(NamedTuple):
     """Simple bounding box."""
@@ -18,3 +13,15 @@ class BBox(NamedTuple):
     min_lat: float
     max_lon: float
     max_lat: float
+
+
+class Coordinates(NamedTuple):
+    """Simple coordinates."""
+
+    lon: float
+    lat: float
+
+
+# Some type aliases
+Polygon = list[Coordinates]
+PolygonsList = list[Polygon]

--- a/pyhgtmap/hgt/__init__.py
+++ b/pyhgtmap/hgt/__init__.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from math import isclose
 from typing import Callable
 
-from pyhgtmap import BBox
+from pyhgtmap import BBox, Coordinates
 
 # Coordinates transformation function prototype
 TransformFunType = Callable[
-    [Iterable[tuple[float, float]]],
-    Iterable[tuple[float, float]],
+    [Iterable[Coordinates]],
+    Iterable[Coordinates],
 ]
 
 
@@ -16,7 +17,27 @@ def makeBBoxString(bbox: BBox) -> str:
     return f"{{0:s}}lon{bbox[0]:.2f}_{bbox[2]:.2f}lat{bbox[1]:.2f}_{bbox[3]:.2f}"
 
 
-def transformLonLats(
+def ensure_aligned_coordinates(
+    low_left: Coordinates,
+    high_left: Coordinates,
+    high_right: Coordinates,
+    low_right: Coordinates,
+) -> None:
+    """
+    Raises ValueError if the tile doesn't map to an aligned rectangle in WSG84 coordinates.
+    """
+    if (
+        not isclose(low_left.lat, low_right.lat)
+        or not isclose(low_left.lon, high_left.lon)
+        or not isclose(high_left.lat, high_right.lat)
+        or not isclose(high_right.lon, low_right.lon)
+    ):
+        raise ValueError(
+            "Tile doesn't map to an aligned rectangle in WSG84 coordinates"
+        )
+
+
+def transform_lon_lats(
     minLon: float,
     minLat: float,
     maxLon: float,
@@ -26,11 +47,22 @@ def transformLonLats(
     if transform is None:
         return BBox(minLon, minLat, maxLon, maxLat)
     else:
-        (lon1, lat1), (lon2, lat2), (lon3, lat3), (lon4, lat4) = transform(
-            [(minLon, minLat), (maxLon, maxLat), (minLon, maxLat), (maxLon, maxLat)],
+        coordinates = transform(
+            [
+                Coordinates(minLon, minLat),
+                Coordinates(minLon, maxLat),
+                Coordinates(maxLon, maxLat),
+                Coordinates(maxLon, minLat),
+            ],
         )
-        minLon = min([lon1, lon2, lon3, lon4])
-        maxLon = max([lon1, lon2, lon3, lon4])
-        minLat = min([lat1, lat2, lat3, lat4])
-        maxLat = max([lat1, lat2, lat3, lat4])
+        low_left, high_left, high_right, low_right = coordinates
+
+        # The resulting projection must be a horizontal rectangle in WSG84 coordinates.
+        ensure_aligned_coordinates(low_left, high_left, high_right, low_right)
+
+        # Do not assume low/high/left/right are the same after transformation
+        minLon = min([x.lon for x in coordinates])
+        maxLon = max([x.lon for x in coordinates])
+        minLat = min([x.lat for x in coordinates])
+        maxLat = max([x.lat for x in coordinates])
         return BBox(minLon, minLat, maxLon, maxLat)

--- a/pyhgtmap/hgt/tile.py
+++ b/pyhgtmap/hgt/tile.py
@@ -8,7 +8,7 @@ import numpy
 import numpy.typing
 
 from pyhgtmap import BBox
-from pyhgtmap.hgt import TransformFunType, makeBBoxString, transformLonLats
+from pyhgtmap.hgt import TransformFunType, makeBBoxString, transform_lon_lats
 from pyhgtmap.hgt.contour import ContoursGenerator, build_contours
 
 if TYPE_CHECKING:
@@ -94,7 +94,7 @@ class HgtTile:
     def bbox(self, doTransform=True) -> BBox:
         """returns the bounding box of the current tile."""
         if doTransform:
-            return transformLonLats(
+            return transform_lon_lats(
                 self.minLon,
                 self.minLat,
                 self.maxLon,


### PR DESCRIPTION
Internal processing expect tiles to be rectangles aligned to WSG84 coordinates. Detect and fail on non-compatible tiles.

Close #51