### PR TITLE
Improve Windows compatibility

### DIFF
--- a/.github/workflows/pythonpackage.yaml
+++ b/.github/workflows/pythonpackage.yaml
@@ -9,10 +9,13 @@ on:
 jobs:
   build:
     strategy:
-      max-parallel: 4
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-        platform: [ubuntu-latest, macos-latest] #, windows-latest]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+        exclude:
+        - # No pybind11-rdp wheel available for Python 3.12 on windows
+          platform: windows-latest
+          python-version: "3.12"
 
     runs-on: ${{ matrix.platform }}
     defaults:

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ dist/
 .*_cache/
 tests/data/
 work/
+/hgt/

--- a/pyhgtmap/hgt/processor.py
+++ b/pyhgtmap/hgt/processor.py
@@ -10,7 +10,7 @@ from pyhgtmap.hgt.file import HgtFile
 from pyhgtmap.output.factory import get_osm_output
 
 if TYPE_CHECKING:
-    from multiprocessing.context import ForkProcess
+    from multiprocessing.context import ForkProcess  # type: ignore[attr-defined]
 
     from pyhgtmap.configuration import Configuration
     from pyhgtmap.hgt.tile import HgtTile
@@ -203,7 +203,7 @@ class HgtFilesProcessor:
             if self.available_children.acquire(block=False):
                 # Ensure "fork" method is used to share parent's process context
                 ctx = multiprocessing.get_context("fork")
-                p = ctx.Process(
+                p = ctx.Process(  # type: ignore[attr-defined]  #TODO: Windows compatibility
                     target=self.run_in_child,
                     args=(func, *args),
                     kwargs=kwargs,

--- a/pyhgtmap/output/osmUtil.py
+++ b/pyhgtmap/output/osmUtil.py
@@ -83,7 +83,7 @@ class Output(pyhgtmap.output.Output):
     def flush(self) -> None:
         self.outF.flush()
 
-    def _write_ways(self, ways: pyhgtmap.output.WaysType, startWayId):
+    def _write_ways(self, ways: pyhgtmap.output.EfficientWaysType, startWayId):
         IDCounter = pyhgtmap.output.Id(startWayId)
         for startNodeId, length, isCycle, elevation in ways:
             IDCounter.curId += 1
@@ -105,7 +105,7 @@ class Output(pyhgtmap.output.Output):
         timestamp_string: str,
         start_node_id: int,
         osm_version: float,
-    ) -> tuple[int, pyhgtmap.output.WaysType]:
+    ) -> tuple[int, pyhgtmap.output.EfficientWaysType]:
         return writeXML(
             self,
             tile_contours,
@@ -166,7 +166,7 @@ def writeXML(
     timestampString,
     start_node_id,
     osm_version,
-) -> tuple[int, pyhgtmap.output.WaysType]:
+) -> tuple[int, pyhgtmap.output.EfficientWaysType]:
     """emits node OSM XML to <output> and collects path information.
 
     <output> may be anything having a write method.  For now, its used with

--- a/pyhgtmap/output/pbfUtil.py
+++ b/pyhgtmap/output/pbfUtil.py
@@ -76,7 +76,7 @@ class Output(pyhgtmap.output.Output):
 
         return osm_header
 
-    def _write_ways(self, ways: pyhgtmap.output.WaysType, startWayId) -> None:
+    def _write_ways(self, ways: pyhgtmap.output.EfficientWaysType, startWayId) -> None:
         """writes ways to self.outf.  ways shall be a list of
         (<startNodeId>, <length>, <isCycle>, <elevation>) tuples.
 
@@ -113,7 +113,7 @@ class Output(pyhgtmap.output.Output):
         timestamp_string: str,
         start_node_id: int,
         osm_version: float,
-    ) -> tuple[int, pyhgtmap.output.WaysType]:
+    ) -> tuple[int, pyhgtmap.output.EfficientWaysType]:
         logger.debug(f"writeNodes - startId: {start_node_id}")
 
         ways: list[pyhgtmap.output.WayType] = []

--- a/pyhgtmap/sources/viewfinder.py
+++ b/pyhgtmap/sources/viewfinder.py
@@ -214,7 +214,7 @@ def fetch_and_extract_zip(zip_url: str, output_dir_name) -> list[str]:
                 ),
                 "wb",
             ) as hgt_file_out:
-                hgt_file_out.write(zip_archive.read(str(file_name)))
+                hgt_file_out.write(zip_archive.read(file_name.as_posix()))
     return [file_name.stem for file_name in file_names]
 
 

--- a/pyhgtmap/varint.py
+++ b/pyhgtmap/varint.py
@@ -10,7 +10,7 @@ def int2str(n) -> bytes:
     return bytes(s)
 
 
-def sint2str(n) -> bytes:
+def sint2str(n: int) -> bytes:
     if n > -1:
         # 0 or positive, shift 1 to the left
         n <<= 1

--- a/tests/hgt/test_processor.py
+++ b/tests/hgt/test_processor.py
@@ -157,6 +157,10 @@ def default_options() -> Configuration:
 
 class TestHgtFilesProcessor:
     @staticmethod
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"),
+        reason="Multiprocessing not supported on Windows",
+    )
     @pytest.mark.parametrize(
         "nb_jobs",
         [
@@ -232,6 +236,10 @@ class TestHgtFilesProcessor:
                 shutil.move(coverage_file, ".")
 
     @staticmethod
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"),
+        reason="Multiprocessing not supported on Windows",
+    )
     @pytest.mark.parametrize(
         "nb_jobs",
         [
@@ -401,6 +409,10 @@ class TestHgtFilesProcessor:
             )
 
     @staticmethod
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"),
+        reason="Multiprocessing not supported on Windows",
+    )
     @pytest.mark.parametrize(
         ("nb_jobs", "nb_jobs_in_use", "expected_fork"),
         [

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -267,6 +267,8 @@ class TestOutputPbf:
                 start,
                 0.6,
             )
+            # Ensure file gets closed
+            osm_output.done()
 
             # Check int32 boundary has been passed without issue
             assert next_node_id == 2147483655


### PR DESCRIPTION
Mainly because numpy's int doesn't behave the same way on all platforms (https://stackoverflow.com/a/57828594/23420157).

This DOESN'T address the main Windows compatibility issue in multiprocessing.

Ref. #7